### PR TITLE
Highlight '[rule] example' in !ex and !example requests

### DIFF
--- a/card.go
+++ b/card.go
@@ -177,20 +177,10 @@ func (card Card) formatLegalities() string {
 	return strings.Join(ret, ",")
 }
 
-// CREATURE
-// Plaguecrafter {2B} |Creature -- Human Shaman| 3/2 When Plaguecrafter enters the battlefield, each player sacrifices a creature or  planeswalker. Each player who can't discards a card. · GRN-U · Vin,Leg,Mod,Std
-// SPELL
-// Momentous Fall {2GG} |Instant| As an additional cost to cast this spell, sacrifice a creature. / You draw cards equal to the sacrificed creature's power, then you gain life equal to its toughness. · ROE-R · Vin,Leg,Mod
-// ENCHANTMENT
-//  Abduction {2UU} |Enchantment -- Aura| Enchant creature / When Abduction enters the battlefield, untap enchanted creature. / You control enchanted creature. / When enchanted creature dies, return that card to the
-//  battlefield under its owner's control. · 6E-U,WL-U · Vin,Leg
-// PLANESWALKER
-//  Jace, Cunning Castaway {1UU} |Legendary Planeswalker -- Jace| 3 loyalty. +1: Whenever one or more creatures you control deal combat damage to a player this turn, draw a card, then discard a card. / -2: Create a 2/2 blue
-// Illusion creature token with "When this creature becomes the target of a spell, sacrifice it." / -5: Create two tokens that are copies of Jace, Cunning Castaway, except they're ...
-// 07:07 <@Datatog> ... not legendary. · XLN-M · Vin,Leg,Mod,Std
 func (card Card) formatCard() string {
 	var s []string
-	s = append(s, card.Name)
+	// Bold card name
+	s = append(s, fmt.Sprintf("\x02%s\x0F", card.Name))
 	if card.ManaCost != "" {
 		s = append(s, card.formatManaCost())
 	}
@@ -236,6 +226,18 @@ func lookupUniqueNamePrefix(input string) string {
 	log.Debug("In lookupUniqueNamePrefix", "C", c)
 	if len(c) == 1 {
 		return c[0]
+	}
+	// Look for something legendary-ish
+	var i int
+	var j string
+	for _, x := range c {
+		if strings.Contains(x, ",") {
+			i++
+			j = x
+		}
+	}
+	if i == 1 {
+		return j
 	}
 	return ""
 }
@@ -361,7 +363,7 @@ func importCardNames(forceFetch bool) ([]string, error) {
 	cardCM, err = closestmatch.Load(cardNamesGob)
 	if err != nil {
 		log.Debug("Cards CM -- Creating from Scratch")
-		cardCM = closestmatch.New(cardNames, []int{2, 3})
+		cardCM = closestmatch.New(cardNames, []int{2, 3, 4, 5, 6, 7})
 		err = cardCM.Save(cardNamesGob)
 		log.Warn("Cards CM", "Error", err)
 	}

--- a/card.go
+++ b/card.go
@@ -367,7 +367,7 @@ func importCardNames(forceFetch bool) ([]string, error) {
 		err = cardCM.Save(cardNamesGob)
 		log.Warn("Cards CM", "Error", err)
 	}
-	log.Debug("Cards CM", "Accuracy", cardCM.AccuracyMutatingWords())
+	// log.Debug("Cards CM", "Accuracy", cardCM.AccuracyMutatingWords())
 	return catalog.Data, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -483,7 +483,10 @@ func handleRulesQuery(input string) string {
 	// Then try normal rules
 	if ruleRegexp.MatchString(input) {
 		log.Debug("In handleRulesQuery", "Rules matched on", ruleRegexp.FindAllStringSubmatch(input, -1)[0][1])
-		return strings.Join(rules[ruleRegexp.FindAllStringSubmatch(input, -1)[0][1]], "\n")
+    ruleNumber := []string{"", input, ". "}
+    ruleText := strings.Join(rules[ruleRegexp.FindAllStringSubmatch(input, -1)[0][1]], "")
+    ruleWithNumber := append(ruleNumber, ruleText, "\n")
+    return strings.Join(ruleWithNumber, "")
 	}
 	// Finally try Glossary entries, people might do "!rule Deathtouch" rather than the proper "!define Deathtouch"
 	if strings.HasPrefix(input, "def ") || strings.HasPrefix(input, "define ") || strings.HasPrefix(input, "rule ") || strings.HasPrefix(input, "r ") || strings.HasPrefix(input, "cr ") {

--- a/main.go
+++ b/main.go
@@ -106,7 +106,7 @@ func printHelp() string {
 func isSenderAnOp(m *hbot.Message) bool {
 	log.Debug("In isSenderAnOp", "Chanops", chanops)
 	var justGotWho bool
-	// Do we now about any ops?
+	// Do we know about any ops?
 	if len(chanops) == 0 {
 		getWho()
 		justGotWho = true
@@ -477,14 +477,19 @@ func handleRulesQuery(input string) string {
 	log.Debug("In handleRulesQuery", "Input", input)
 	// Match example first, for !ex101.a and !example 101.1a so the rule regexp doesn't eat it as a normal rule
 	if (strings.HasPrefix(input, "ex") || strings.HasPrefix(input, "example ")) && ruleRegexp.MatchString(input) {
-		log.Debug("In handleRulesQuery", "Example matched on", ruleRegexp.FindAllStringSubmatch(input, -1)[0][1])
-		return strings.Join(rules["ex"+ruleRegexp.FindAllStringSubmatch(input, -1)[0][1]], "\n")
+    foundRuleNum := ruleRegexp.FindAllStringSubmatch(input, -1)[0][1]
+		log.Debug("In handleRulesQuery", "Example matched on", foundRuleNum)
+    exampleNumber := []string{"[", foundRuleNum, ".] Example: "}
+    exampleText := strings.Join(rules["ex"+foundRuleNum], "")[9:]
+    formattedExample := append(exampleNumber, exampleText, "\n")
+		return strings.Join(formattedExample, "")
 	}
 	// Then try normal rules
 	if ruleRegexp.MatchString(input) {
-		log.Debug("In handleRulesQuery", "Rules matched on", ruleRegexp.FindAllStringSubmatch(input, -1)[0][1])
-    ruleNumber := []string{"", input, ". "}
-    ruleText := strings.Join(rules[ruleRegexp.FindAllStringSubmatch(input, -1)[0][1]], "")
+    foundRuleNum := ruleRegexp.FindAllStringSubmatch(input, -1)[0][1]
+		log.Debug("In handleRulesQuery", "Rules matched on", foundRuleNum)
+    ruleNumber := []string{"", foundRuleNum, ". "}
+    ruleText := strings.Join(rules[foundRuleNum], "")
     ruleWithNumber := append(ruleNumber, ruleText, "\n")
     return strings.Join(ruleWithNumber, "")
 	}
@@ -626,7 +631,7 @@ var MainTrigger = hbot.Trigger{
 			if s != "" {
 				// Check if we've already sent it recently
 				if _, found := recentsCache.Get(s); found {
-					irc.Reply(m, fmt.Sprintf("Duplicate response withheld. (%s ...)", s[:23]))
+					irc.Reply(m, fmt.Sprintf("Duplicate response witheld. (%s ...)", s[:23]))
 					continue
 				}
 				recentsCache.Set(s, true, cache.DefaultExpiration)

--- a/main.go
+++ b/main.go
@@ -631,7 +631,7 @@ var MainTrigger = hbot.Trigger{
 			if s != "" {
 				// Check if we've already sent it recently
 				if _, found := recentsCache.Get(s); found {
-					irc.Reply(m, fmt.Sprintf("Duplicate response witheld. (%s ...)", s[:23]))
+					irc.Reply(m, fmt.Sprintf("Duplicate response withheld. (%s ...)", s[:23]))
 					continue
 				}
 				recentsCache.Set(s, true, cache.DefaultExpiration)


### PR DESCRIPTION
Closes #12.

Note that this isn't robust as possible. Right now it's hard-slicing the string from [9:] which works when every example starts with "Example: ", but it may need to be revisited if that changes later.