### PR TITLE
Fix issue with finding too many 'legendary-ish' cards.

### DIFF
--- a/card.go
+++ b/card.go
@@ -297,15 +297,11 @@ func lookupUniqueNamePrefix(input string) string {
 	}
 	// Look for something legendary-ish
 	var i int
-	var j string
 	for _, x := range c {
 		if strings.Contains(x, ",") || strings.Contains(x, "the") {
 			i++
-			j = x
+			return x
 		}
-	}
-	if i == 1 {
-		return j
 	}
 	return ""
 }

--- a/card.go
+++ b/card.go
@@ -296,10 +296,8 @@ func lookupUniqueNamePrefix(input string) string {
 		return c[0]
 	}
 	// Look for something legendary-ish
-	var i int
 	for _, x := range c {
 		if strings.Contains(x, ",") || strings.Contains(x, "the") {
-			i++
 			return x
 		}
 	}


### PR DESCRIPTION
The logic before would only return a cardname if it was the *only* card with 'the' or ',' in the name. This worked fine for Arcades, but not so much for, say, Bruna (who has 2) or Teysa (who has 3).