### PR TITLE
Remove Vanguards from results.

### DIFF
--- a/card.go
+++ b/card.go
@@ -371,7 +371,7 @@ func fetchScryfallCardByFuzzyName(input string) (Card, error) {
 			raven.CaptureError(err, nil)
 			return card, fmt.Errorf("Something went wrong parsing the card")
 		}
-		if (card.BorderColor != "black" && card.BorderColor != "white") || strings.Contains(card.Layout, "token") {
+		if (card.BorderColor != "black" && card.BorderColor != "white") || strings.Contains(card.Layout, "vanguard") ||  strings.Contains(card.Layout, "token") {
 			return emptyCard, fmt.Errorf("Dumb card returned, keep trying")
 		}
 		return card, nil


### PR DESCRIPTION
Xantcha, Barrin, etc are exact matches for Vanguard card names, so fuzzy match was always going to give us those. So let's just... see if it's a vanguard, and if it is, discard it.

Fixes #124 