### PR TITLE
Let user know how many rulings a card has in 'too many rulings'

### DIFF
--- a/card.go
+++ b/card.go
@@ -275,7 +275,7 @@ func (card *Card) getRulings(rulingNumber int) string {
 		return "Ruling not found"
 	}
 	if len(ret) > 3 {
-		return "Too many rulings, please request a specific one"
+		return fmt.Sprintf("Too many rulings (%d), please request a specific one", len(ret))
 	}
 	return strings.Join(ret, "\n")
 }


### PR DESCRIPTION
Trivial change - someone suggested that if a card has too many rulings, we include _how many_ rulings it has. Minor QoL tweak really.