### PR TITLE
Added shorthand for Asmo

### DIFF
--- a/short_names.json
+++ b/short_names.json
@@ -28,5 +28,11 @@
   }, {
     "shortname": "tim",
     "fullname": "Prodigal Sorcerer"
+  }, {
+    "shortname": "asmo",
+	"fullname": "Asmoranomardicadaistinaculdacar"
+  }, {
+    "shortname": "asmor",
+	"fullname": "Asmoranomardicadaistinaculdacar"
   }
 ]


### PR DESCRIPTION
Added an entry for Asmo in `shorthand_names`, because screw typing all that. Made a shortcut to both Asmo and Asmor, because we couldn't agree on what was more correct and, in the wise words of @Villawhatever, 
> add em both who gives a fuck
> oh no 18 extra bytes