### PR TITLE
Fix Uro

### DIFF
--- a/card.go
+++ b/card.go
@@ -419,7 +419,7 @@ func fetchScryfallCardByFuzzyName(input string, isLang bool) (Card, error) {
 		if (card.BorderColor != "black" && card.BorderColor != "white" && card.BorderColor != "borderless") || strings.Contains(card.Layout, "vanguard") || (strings.Contains(card.Layout, "token") && !(strings.Contains(card.TypeLine, "Dungeon"))) || strings.Contains(card.Layout, "art_series") || card.SetType == "funny" || card.Set == "fjmp" {
 			return emptyCard, fmt.Errorf("Dumb card returned, keep trying")
 		}
-		return card, nil 
+		return card, nil
 	}
 	log.Info("fetchScryfallCard: Scryfall returned a non-200", "Status Code", resp.StatusCode)
 	return card, fmt.Errorf("Card not found by Scryfall")

--- a/card.go
+++ b/card.go
@@ -426,7 +426,7 @@ func fetchScryfallCardByFuzzyName(input string, isLang bool) (Card, error) {
 }
 
 func HandleForeignCardOverlapCases(input string) (string, error) {
-	log.Debug(fmt.Sprintf("Handling foreign card overlap for '%s'", input))
+	log.Debug("Handling foreign card overlap", "Card", input)
 	if uroRegex.MatchString(input) {
 		log.Debug("\tThey probably wanted Uro, Titan of Nature's Wrath")
 		return "Uro, Titan of Nature's Wrath", nil

--- a/card.go
+++ b/card.go
@@ -426,7 +426,7 @@ func fetchScryfallCardByFuzzyName(input string, isLang bool) (Card, error) {
 }
 
 func handleForeignCardOverlapCases(input string) string {
-	log.Debug("Handling foreign card overlap for '%s'", input)
+	log.Debug(fmt.Sprintf("Handling foreign card overlap for '%s'", input))
 	if uroRegex.MatchString(input) {
 		log.Debug("\tThey probably wanted Uro, Titan of Nature's Wrath")
 		return "Uro, Titan of Nature's Wrath"

--- a/card.go
+++ b/card.go
@@ -410,8 +410,8 @@ func fetchScryfallCardByFuzzyName(input string, isLang bool) (Card, error) {
 		}
 		if !isLang && card.Lang != "en" {
 			log.Debug("Got back a foreign card when it wasn't requested, let's try again")
-			coercedName := handleForeignCardOverlapCases(input)
-			if coercedName != "" {
+			coercedName, err := HandleForeignCardOverlapCases(input)
+			if err == nil && coercedName != "" {
 				card.Name = coercedName
 			}
 			return fetchScryfallCardByFuzzyName(card.Name, false)
@@ -419,19 +419,19 @@ func fetchScryfallCardByFuzzyName(input string, isLang bool) (Card, error) {
 		if (card.BorderColor != "black" && card.BorderColor != "white" && card.BorderColor != "borderless") || strings.Contains(card.Layout, "vanguard") || (strings.Contains(card.Layout, "token") && !(strings.Contains(card.TypeLine, "Dungeon"))) || strings.Contains(card.Layout, "art_series") || card.SetType == "funny" || card.Set == "fjmp" {
 			return emptyCard, fmt.Errorf("Dumb card returned, keep trying")
 		}
-		return card, nil
+		return card, nil 
 	}
 	log.Info("fetchScryfallCard: Scryfall returned a non-200", "Status Code", resp.StatusCode)
 	return card, fmt.Errorf("Card not found by Scryfall")
 }
 
-func handleForeignCardOverlapCases(input string) string {
+func HandleForeignCardOverlapCases(input string) (string, error) {
 	log.Debug(fmt.Sprintf("Handling foreign card overlap for '%s'", input))
 	if uroRegex.MatchString(input) {
 		log.Debug("\tThey probably wanted Uro, Titan of Nature's Wrath")
-		return "Uro, Titan of Nature's Wrath"
+		return "Uro, Titan of Nature's Wrath", nil
 	}
-	return ""
+	return "", nil
 }
 
 func fetchDumbScryfallCardByName(input string, isLang bool) (Card, error) {

--- a/card.go
+++ b/card.go
@@ -410,6 +410,10 @@ func fetchScryfallCardByFuzzyName(input string, isLang bool) (Card, error) {
 		}
 		if !isLang && card.Lang != "en" {
 			log.Debug("Got back a foreign card when it wasn't requested, let's try again")
+			coercedName := handleForeignCardOverlapCases(input)
+			if coercedName != "" {
+				card.Name = coercedName
+			}
 			return fetchScryfallCardByFuzzyName(card.Name, false)
 		}
 		if (card.BorderColor != "black" && card.BorderColor != "white" && card.BorderColor != "borderless") || strings.Contains(card.Layout, "vanguard") || (strings.Contains(card.Layout, "token") && !(strings.Contains(card.TypeLine, "Dungeon"))) || strings.Contains(card.Layout, "art_series") || card.SetType == "funny" || card.Set == "fjmp" {
@@ -419,6 +423,15 @@ func fetchScryfallCardByFuzzyName(input string, isLang bool) (Card, error) {
 	}
 	log.Info("fetchScryfallCard: Scryfall returned a non-200", "Status Code", resp.StatusCode)
 	return card, fmt.Errorf("Card not found by Scryfall")
+}
+
+func handleForeignCardOverlapCases(input string) string {
+	log.Debug("Handling foreign card overlap for '%s'", input)
+	if uroRegex.MatchString(input) {
+		log.Debug("\tThey probably wanted Uro, Titan of Nature's Wrath")
+		return "Uro, Titan of Nature's Wrath"
+	}
+	return ""
 }
 
 func fetchDumbScryfallCardByName(input string, isLang bool) (Card, error) {

--- a/card_test.go
+++ b/card_test.go
@@ -514,3 +514,23 @@ func TestSearchResultHandling(t *testing.T) {
 		}
 	}
 }
+
+func TestCoerceRealNamesFromForeignHiccups(t *testing.T) {
+	tables := []struct {
+		input string
+		output   string
+	}{
+		{"Uro,", "Uro, Titan of Nature's Wrath" },
+		{"Uro",  "Uro, Titan of Nature's Wrath" },
+		{"uro",  "Uro, Titan of Nature's Wrath" },
+	}
+	for _, table := range tables {
+		got, err := HandleForeignCardOverlapCases(table.input)
+		if err != nil {
+			t.Errorf("Something broke: %s", err)
+		}
+		if got != table.output {
+			t.Errorf("Incorrect output -- got %s -- want %s", got, table.output)
+		}
+	}
+}

--- a/card_test.go
+++ b/card_test.go
@@ -517,8 +517,8 @@ func TestSearchResultHandling(t *testing.T) {
 
 func TestCoerceRealNamesFromForeignHiccups(t *testing.T) {
 	tables := []struct {
-		input string
-		output   string
+		input  string
+		output string
 	}{
 		{"Uro,", "Uro, Titan of Nature's Wrath" },
 		{"Uro",  "Uro, Titan of Nature's Wrath" },

--- a/utils.go
+++ b/utils.go
@@ -50,8 +50,11 @@ var (
 	nonAlphaRegex  = regexp.MustCompile(`\W+`)
 	emojiRegex     = regexp.MustCompile(`{\d+}|{[A-Z]}|{\d\/[A-Z]}|{[A-Z]\/[A-Z]}`)
 
-	//Super rudimentary policy regex to parse e.g '4.8' into 4-8 for link generation
+	// Super rudimentary policy regex to parse e.g '4.8' into 4-8 for link generation
 	policyRegex = regexp.MustCompile(`[^0-9]+`)
+
+	// We PROBABLY want Uro, not Aurochs
+	uroRegex = regexp.MustCompile(`^[Uu]ro,?$`)
 
 	// Metrics
 	totalLines             = expvar.NewInt("bot_totalLines")


### PR DESCRIPTION
`Uro` has been returning `Aurochs` for a while now, since "Uro" is the Spanish name for that card. Added a new function where we can throw this and any other special cases that will coerce an "Uro" into the card's canonical name before performing another fuzzy search.