### PR TITLE
Implement Momir and qualified !random

### DIFF
--- a/card.go
+++ b/card.go
@@ -131,7 +131,7 @@ func (card *Card) getFlavourText() string {
 		return card.Metadata.PreviousFlavourTexts[0]
 	}
 	if isDfc(card) {
-		return getDfcFlavourText(card);
+		return getDfcFlavourText(card)
 	}
 	return noFlavourText
 }
@@ -144,14 +144,14 @@ func getDfcFlavourText(card *Card) string {
 	var parts []string
 
 	for _, s := range card.CardFaces {
-		flavour := s.FlavourText;
-		if (len(flavour) > 0) {
+		flavour := s.FlavourText
+		if len(flavour) > 0 {
 			parts = append(parts, flavour)
 		}
 	}
-	dfcFlavour = strings.Join(parts, ` \\ `);
+	dfcFlavour = strings.Join(parts, ` \\ `)
 
-	if (len(dfcFlavour) > 0 ) {
+	if len(dfcFlavour) > 0 {
 		return dfcFlavour
 	}
 
@@ -635,11 +635,18 @@ func getDumbScryfallCard(input string, isLang bool) (Card, error) {
 	return card, fmt.Errorf("No card found")
 }
 
-func getRandomScryfallCard() (Card, error) {
+func getRandomScryfallCard(cardTokens []string) (Card, error) {
 	randomRequests.Add(1)
 	var card Card
-	log.Debug("GetRandomScryfallCard: Attempting to fetch", "URL", scryfallRandomAPIURL)
-	resp, err := http.Get(scryfallRandomAPIURL)
+	u, _ := url.Parse(scryfallRandomAPIURL)
+	if len(cardTokens) > 0 {
+		q := u.Query()
+		q.Set("q", strings.Join(cardTokens, " "))
+		u.RawQuery = q.Encode()
+	}
+
+	log.Debug("GetRandomScryfallCard: Attempting to fetch", "URL", u.String())
+	resp, err := http.Get(u.String())
 	if err != nil {
 		raven.CaptureError(err, nil)
 		log.Error("getRandomScryfallCard: The HTTP request failed", "Error", err)
@@ -711,7 +718,7 @@ func ParseAndFormatSearchResults(csr CardSearchResult) ([]Card, error) {
 			}
 		}
 	}
-	if (csr.Warnings != nil) {
+	if csr.Warnings != nil {
 		return []Card{}, fmt.Errorf(strings.Join(csr.Warnings, " "))
 	}
 	switch {

--- a/main_test.go
+++ b/main_test.go
@@ -43,13 +43,13 @@ func fakeGetCard(cardname string, isLang bool) (Card, error) {
 	return Card{Name: "CARD", Set: "TestSet", Rarity: "TestRare", ID: cardname}, nil
 }
 
-func fakeGetRandomCard() (Card, error) {
+func fakeGetRandomCard(_ []string) (Card, error) {
 	return Card{Name: "RANDOMCARD", Set: "RandomTestSet", Rarity: "RandomTestRare", ID: "randomCard"}, nil
 }
 
 func fakeFindCards(tokens []string) ([]Card, error) {
-	card1, _ := fakeGetRandomCard()
-	card2, _ := fakeGetRandomCard()
+	card1, _ := fakeGetRandomCard(tokens)
+	card2, _ := fakeGetRandomCard(tokens)
 	return []Card{card1, card2}, nil
 }
 
@@ -141,6 +141,8 @@ func TestTokens(t *testing.T) {
 		{"To", []string{""}},
 		{"Too", []string{testCardExpected}},
 		{"random", []string{testRandomCardExpected}},
+		{"!random color:blue", []string{testRandomCardExpected}},
+		{"!momir 5", []string{testRandomCardExpected}},
 		{"!rule of law", []string{testCardExpected}},
 		// {"Hello! I was wondering if Selvala, Explorer Returned flip triggers work. If I use Selvala and two nonlands are revealed, is that two triggers of life & mana gain", emptyStringSlice}, -- WONTFIX https://github.com/Fryyyyy/Fryatog/issues/42
 		{"!search o:test", []string{testRandomCardExpected + "\n" + testRandomCardExpected}},


### PR DESCRIPTION
Resolves #8

Not sure anyone was asking for this anymore, but here it is anyway :slightly_smiling_face: 

Added a new command, `!momir <n>`, which accepts a number as a parameter and returns a random creature with mana value `n`. As a natural follow-up to this, I also extended the syntax for `!random` to allow for any Scryfall query string as an argument, which restricts the pool of random choices only to those cards matching the search. 