### PR TITLE
Fix roll regex, update a bunch of others

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ config.json*
 *.exe
 [fF]ryatog
 vendor/*
+.idea/

--- a/card.go
+++ b/card.go
@@ -439,10 +439,6 @@ func fetchScryfallCardByFuzzyName(input string, isLang bool) (Card, error) {
 		}
 		if !isLang && card.Lang != "en" {
 			log.Debug("Got back a foreign card when it wasn't requested, let's try again")
-			coercedName, err := HandleForeignCardOverlapCases(input)
-			if err == nil && coercedName != "" {
-				card.Name = coercedName
-			}
 			return fetchScryfallCardByFuzzyName(card.Name, false)
 		}
 		if IsDumbCard(card) {
@@ -452,15 +448,6 @@ func fetchScryfallCardByFuzzyName(input string, isLang bool) (Card, error) {
 	}
 	log.Info("fetchScryfallCard: Scryfall returned a non-200", "Status Code", resp.StatusCode)
 	return card, fmt.Errorf("Card not found by Scryfall")
-}
-
-func HandleForeignCardOverlapCases(input string) (string, error) {
-	log.Debug("Handling foreign card overlap", "Card", input)
-	if uroRegex.MatchString(input) {
-		log.Debug("\tThey probably wanted Uro, Titan of Nature's Wrath")
-		return "Uro, Titan of Nature's Wrath", nil
-	}
-	return "", nil
 }
 
 func IsDumbCard(card Card) bool {

--- a/card_test.go
+++ b/card_test.go
@@ -523,26 +523,6 @@ func TestSearchResultHandling(t *testing.T) {
 	}
 }
 
-func TestCoerceRealNamesFromForeignHiccups(t *testing.T) {
-	tables := []struct {
-		input  string
-		output string
-	}{
-		{"Uro,", "Uro, Titan of Nature's Wrath"},
-		{"Uro", "Uro, Titan of Nature's Wrath"},
-		{"uro", "Uro, Titan of Nature's Wrath"},
-	}
-	for _, table := range tables {
-		got, err := HandleForeignCardOverlapCases(table.input)
-		if err != nil {
-			t.Errorf("Something broke: %s", err)
-		}
-		if got != table.output {
-			t.Errorf("Incorrect output -- got %s -- want %s", got, table.output)
-		}
-	}
-}
-
 func TestIsDumbCard(t *testing.T) {
 	tables := []struct {
 		jsonFile string

--- a/utils.go
+++ b/utils.go
@@ -22,18 +22,18 @@ var (
 
 	//Stuff pared from main.go
 	botCommandRegex      = regexp.MustCompile(`[!&]([^=!&?[)][^!&?[)]+)\.\s|[!&]([^=!&?[)][^!&?[)]+)|\[\[(.*?)\]\]`)
-	singleQuotedWord     = regexp.MustCompile(`^(?:\"|\')\w+(?:\"|\')$`)
-	nonTextRegex         = regexp.MustCompile(`^[^\w]+$`)
-	wordEndingInBang     = regexp.MustCompile(`!(?:"|') |(?:\n)+`)
-	wordStartingWithBang = regexp.MustCompile(`\s+!(?: *)\S+`)
+	singleQuotedWord     = regexp.MustCompile(`^(?:"\w+"|'\w+')$`)
+	nonTextRegex         = regexp.MustCompile(`^\W+$`)
+	wordEndingInBang     = regexp.MustCompile(`!["'] |\n+`)
+	wordStartingWithBang = regexp.MustCompile(`\s+! *\S+`)
 
-	diceRegex = regexp.MustCompile(`(?:roll)?(?:\s*)(.*?)(?:d(\d+)([+-]\d+)?)`)
+	diceRegex = regexp.MustCompile(`^(?:roll )?\s*(.*?)d(\d+)([+-]\d+)?`)
 
-	cardMetadataRegex = regexp.MustCompile(`(?i)^(?:ruling(?:s?)|reminder|flavo(?:u?)r)(?: )`)
+	cardMetadataRegex = regexp.MustCompile(`(?i)^(?:rulings?|reminder|flavou?r) `)
 
 	gathererRulingRegex = regexp.MustCompile(`^(?:(?P<start_number>\d+) ?(?P<name>.+)|(?P<name2>.*?) ?(?P<end_number>\d+).*?|(?P<name3>.+))`)
 
-	seeRuleRegexp = regexp.MustCompile(`rule (\d+\.{0,1}\d*\w?)`)
+	seeRuleRegexp = regexp.MustCompile(`rule (\d+\.?\d*\w?)`)
 
 	noPunctuationRegex = regexp.MustCompile(`\W$`)
 
@@ -42,18 +42,15 @@ var (
 	ruleRegexp        = regexp.MustCompile(ruleRegexpLiteral)
 	ruleExampleRegexp = regexp.MustCompile(`(\d+) ` + ruleRegexpLiteral + `|` + ruleRegexpLiteral + ` (\d+)` + `|` + ruleRegexpLiteral)
 
-	greetingRegexp = regexp.MustCompile(`(?i)^h(ello|i)( *)(\!|\.|\?)*( *)$`)
+	greetingRegexp = regexp.MustCompile(`(?i)^h(ello|i) *[!.?]* *$`)
 
 	//Stuff pared from card.go
 	reminderRegexp = regexp.MustCompile(`\((.*?)\)`)
 	nonAlphaRegex  = regexp.MustCompile(`\W+`)
-	emojiRegex     = regexp.MustCompile(`{\d+}|{[A-Z]}|{\d\/[A-Z]}|{[A-Z]\/[A-Z]}`)
+	emojiRegex     = regexp.MustCompile(`{\d+}|{[A-Z]}|{\d/[A-Z]}|{[A-Z]/[A-Z]}`)
 
 	// Super rudimentary policy regex to parse e.g '4.8' into 4-8 for link generation
 	policyRegex = regexp.MustCompile(`[^0-9]+`)
-
-	// We PROBABLY want Uro, not Aurochs
-	uroRegex = regexp.MustCompile(`^[Uu]ro,?$`)
 
 	// Metrics
 	totalLines             = expvar.NewInt("bot_totalLines")


### PR DESCRIPTION
The regex for file rolling wasn't anchored to the beginning of the query, so searches such as `!search o:"roll a d20"` were triggering the roll command instead of the search command. That has been fixed.

While I was there, I also did some cleanup to the other regexps that we use:
- `singleQuotedWord` was rewritten to only use matching quotes
- Unnecessary non-capturing groups (and capturing groups which weren't used) were removed
- Single character alternate groups `(a|b|c)` were replaced with `[abc]`
- Some unnecessary escape characters were removed
- A space was inserted after the roll command so that `!rolld20` is not valid (since that's just weird)
- Negations of groups which have explicit negated counterparts were replaced (`\S` instead of `[^\s]`)

I also removed the logic that special-cased Uro as a foreign card. Firstly because I wasn't actually able to replicate the issue (`!uro` just returns Uro even when that thing is removed), and secondly because even if it does appear again, we can fix it just by adding `"uro"` into the short names dictionary.