### PR TITLE
Actual roll command fix

### DIFF
--- a/dice_test.go
+++ b/dice_test.go
@@ -31,7 +31,6 @@ func TestRollDice(t *testing.T) {
 		{"2d6+e", plannedFailure},
 		{"2e6?_", plannedFailure},
 		{"-3d8", plannedFailure},
-		{"kd4", plannedError},
 		{"3d1", plannedError},
 		{"2d112", plannedError},
 		{"4d0", plannedError},

--- a/utils.go
+++ b/utils.go
@@ -27,7 +27,7 @@ var (
 	wordEndingInBang     = regexp.MustCompile(`!["'] |\n+`)
 	wordStartingWithBang = regexp.MustCompile(`\s+! *\S+`)
 
-	diceRegex = regexp.MustCompile(`^(?:roll )?\s*(.*?)d(\d+)([+-]\d+)?`)
+	diceRegex = regexp.MustCompile(`^(?:roll\s+)?(\d*)d(\d+)([+-]\d+)?`)
 
 	cardMetadataRegex = regexp.MustCompile(`(?i)^(?:rulings?|reminder|flavou?r) `)
 


### PR DESCRIPTION
Turns out, the fix to dice rolling introduced in #214 wasn't quite complete, as it wasn't enough to add the beginning of string anchor. 

### Issue
Because the `roll` command is optional, when something like `search o:"roll a d20"` is matched, the `search o:roll a` part is all matched to the "number of dice" part of the regex, which captures `(.*?)` -- meaning anything. The reason the capture is so broad is probably to be able to catch and alert on malformed rolls, but it creates this issue where it can overmatch things that aren't supposed to be roll commands. See https://regex101.com/r/fVX4fm/1.

### Fix
There are several options to fix this, each with its own slight change in behavior:
1.  Require the `roll` command word to be present. That's probably the most "consistent" fix, as right now dice rolling is the only command (aside from fetching cards of course) that has an optional command word. It does mean some loss of convenience though, as `!d20` no longer becomes possible.
2. Restrict the "number of dice" group to digits only. This would mean that `5d6` can match, but `"foo"d6` cannot. I would consider this the "cleanest" fix, as it brings the regex closer to what it's actually intended to match. We do lose some of the aforementioned alerting on malformed rolls, but there's an argument to be made that the line on what's considered a malformed roll is a bit arbitrary in the first place. Why do we need to report "malformed roll" on `!roll xd5`, but not on `!roll 5dx` or `!roll a die`? Personally, I would save the "malformed roll" messages for things that can't be caught by the regex, such as numbers that are outside the accepted range.
3. Restrict the "number of dice" group, but less. For example, we could say that it *can* contain non-digit characters, but can't include spaces. That would still match `"foo"d6` as a malformed roll, but would fix the `search o:d20` problem. That's the least invasive option (it makes all tests pass), but it feels like a kind of weird compromise that's more about trying to break as little as possible than it is about fixing the actual issue. Why is a space not allowed, but a semicolon can be, you know?
4. Reorder the regex matching. If the dice roll regex is the last one to be checked, then any other command that would contain a `dN` string doesn't have to worry, because we'll never get to trying to interpret the command as a dice roll. This I don't like for two reasons; one, it suddenly makes the order in which we match regexes important, which is a really sneaky thing to care about, and two, it unexpectedly breaks if WotC ever prints a card with "d4" in its name (as the default card search command does have to be after everything else, obviously).
5. Go nuts. I could dive in and craft some super-long regex that applies some combination of the above (let's say it matches anything if using the `roll` keyword, but only digits when using the implicit command). That seems like it would be a lot of work that ends up with a messy, unreadable regexes, all for a *very* slight benefit. (Also, that's usually a sign that regex may be the wrong tool to use).

This PR implements option 2, as that's my preferred one, but I'm open to discussion about the others.