### PR TITLE
Fix dice rolling calculation

### DIFF
--- a/dice.go
+++ b/dice.go
@@ -20,11 +20,11 @@ type Roll struct {
 
 func (d Roll) calculate() string {
 	if d.sides == 0 {
-		return fmt.Sprintf("1 %d-sided die: %d", d.number, rand.Intn(d.number-1)+1)
+		return fmt.Sprintf("1 %d-sided die: %d", d.number, rand.Intn(d.number)+1)
 	}
 	var result int
 	for i := 1; i <= d.number; i++ {
-		result += rand.Intn(d.sides-1) + 1
+		result += rand.Intn(d.sides) + 1
 	}
 
 	if d.operand != 0 {


### PR DESCRIPTION
The way individual dice rolls were created was incorrect.

If we calculate a roll of a d6 (`d.sides == 6`), we want to generate a random number between 0 and 5, then add one. However, since the range of `rand.Intn` isn't inclusive, calling `rand.Intn(5)` (which is what we're doing for a d6) can only produce numbers from 0 to 4, giving us a result between 1 and 5. This effectively means the highest value can never be rolled. The easiest way to test this is to roll some d2's, they'll always come out as one. (`99d2` always results in a 99).

This PR fixes this off-by-one error by setting the correct upper limit.