### PR TITLE
Extend coin flip syntax to support multiple flips

### DIFF
--- a/dice.go
+++ b/dice.go
@@ -118,9 +118,58 @@ func validateDice(input string, dice []string) (Roll, error) {
 	return wellFormedDice, nil
 }
 
-func flipCoin() string {
-	coin := []string{"Heads", "Tails"}
-	side := coin[rand.Intn(len(coin))]
+func flipCoin(input string) string {
+	coinCount, err := parseCoinCount(input)
+	if err != nil {
+		return err.Error()
+	}
 
-	return fmt.Sprintf("%s.", side)
+	flips := make([]int, coinCount)
+	for i := 0; i < coinCount; i++ {
+		flips[i] = rand.Intn(2)
+	}
+	return formatFlips(flips, coinCount)
 }
+
+func parseCoinCount(input string) (int, error) {
+	coinMaximum := 50
+
+	coins := coinRegex.FindStringSubmatch(input)
+	if coins[1] == "" {
+		// no number specified - implicit one flip
+		return 1, nil
+	}
+
+	numCoins, err := strconv.Atoi(coins[1])
+	if err != nil {
+		return 0, errors.New("malformed coin toss")
+	}
+
+	if numCoins > coinMaximum {
+		return 0, errors.New("malformed coin toss (max count is 50)")
+	}
+	if numCoins < 1 {
+		return 0, errors.New("malformed coin toss (min count is 1)")
+	}
+	return numCoins, nil
+}
+
+func formatFlips(flips []int, count int) string {
+	prefix := ""
+	coinNames := []string{"Heads", "Tails"}
+	joiner := ", "
+	if count > 5 {
+		prefix = fmt.Sprintf("%d coins: ", count)
+		coinNames = []string{"H", "T"}
+		joiner = ""
+	}
+
+	formatted := make([]string, len(flips))
+	for i := 0; i < len(formatted); i++ {
+		formatted[i] = coinNames[flips[i]]
+	}
+
+	return fmt.Sprintf("%s%s.", prefix, strings.Join(formatted, joiner))
+}
+
+

--- a/dice_test.go
+++ b/dice_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestFlipCoin(t *testing.T) {
 	for i := 1; i < 10; i++ {
-		result := flipCoin()
+		result := flipCoin("coin")
 		validOutput := regexp.MustCompile(`(?:Heads|Tails).`)
 		if !(validOutput.MatchString(result)) {
 			t.Errorf(`FAIL: Expected heads or tails in output, but result was \"%s\"`, result)

--- a/dice_test.go
+++ b/dice_test.go
@@ -7,12 +7,40 @@ import (
 )
 
 func TestFlipCoin(t *testing.T) {
+	validOutput := regexp.MustCompile(`(?:Heads|Tails).`)
 	for i := 1; i < 10; i++ {
 		result := flipCoin("coin")
-		validOutput := regexp.MustCompile(`(?:Heads|Tails).`)
 		if !(validOutput.MatchString(result)) {
 			t.Errorf(`FAIL: Expected heads or tails in output, but result was \"%s\"`, result)
 		}
+	}
+
+	validOutput = regexp.MustCompile(`(?:(?:Heads|Tails), ){2}(?:Heads|Tails)\.`)
+	for i := 1; i < 10; i++ {
+		result := flipCoin("coin 3")
+		if !(validOutput.MatchString(result)) {
+			t.Errorf(`FAIL: Expected list of heads or tails in output, but result was \"%s\"`, result)
+		}
+	}
+
+	validOutput = regexp.MustCompile(`10 coins: [HT]{10}\.`)
+	for i := 1; i < 10; i++ {
+		result := flipCoin("coin 10")
+		if !(validOutput.MatchString(result)) {
+			t.Errorf(`FAIL: Expected list of H or T in output, but result was \"%s\"`, result)
+		}
+	}
+
+	errorMsg := "malformed coin toss (max count is 50)"
+	result := flipCoin("coin 99")
+	if result != errorMsg {
+		t.Errorf(`FAIL: Expected count exceeded error, got "%s"`, result)
+	}
+
+	errorMsg = "malformed coin toss (min count is 1)"
+	result = flipCoin("coin 0")
+	if result != errorMsg {
+		t.Errorf(`FAIL: Expected count subceeded error, got "%s"`, result)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -161,7 +161,7 @@ func printHelp() string {
 	ret = append(ret, "!uncard/vanguard/plane/scheme <cardname> to bring up normally filtered out cards")
 	ret = append(ret, "!url <mtr/ipg/cr/jar> to bring up the links to policy documents")
 	ret = append(ret, "!roll <X> to roll X-sided die; !roll <XdY> to roll X Y-sided dice")
-	ret = append(ret, "!coin to flip a coin (heads/tails)")
+	ret = append(ret, "!coin to flip a coin (heads/tails); !coin <X> to flip X coins")
 	ret = append(ret, "https://github.com/Fryyyyy/Fryatog/issues for bugs & feature requests")
 	return strings.Join(ret, " · ")
 }
@@ -434,9 +434,9 @@ func handleCommand(params *fryatogParams, c chan string) {
 		c <- rollDice(message)
 		return
 
-	case message == "coin":
+	case coinRegex.MatchString(message):
 		log.Debug("Coin flip")
-		c <- flipCoin()
+		c <- flipCoin(message)
 		return
 
 	case ruleRegexp.MatchString(message),

--- a/utils.go
+++ b/utils.go
@@ -28,6 +28,7 @@ var (
 	wordStartingWithBang = regexp.MustCompile(`\s+! *\S+`)
 
 	diceRegex = regexp.MustCompile(`^(?:roll )?\s*(.*?)d(\d+)([+-]\d+)?`)
+	coinRegex = regexp.MustCompile(`^coin(?:\s+(\d+))?`)
 
 	cardMetadataRegex = regexp.MustCompile(`(?i)^(?:rulings?|reminder|flavou?r) `)
 


### PR DESCRIPTION
Just as a small nice-to-have, sometimes you want to flip more than one coin. This PR extends the coin command to support an optional numeric parameter.

Example queries:
```
<vaasa> !coin
<vaasatog> Heads.
<vaasa> !coin 1
<vaasatog> Heads.
<vaasa> !coin 3
<vaasatog> Tails, Heads, Heads.
<vaasa> !coin 15
<vaasatog> 15 coins: TTHHTHTTTTTTTTT.
<vaasa> !coin 1000
<vaasatog> malformed coin toss (max count is 50)
<vaasa> !coin 0
<vaasatog> malformed coin toss (min count is 1)
```