### PR TITLE
Allow for long random search terms.

### DIFF
--- a/main.go
+++ b/main.go
@@ -308,7 +308,7 @@ func tokeniseAndDispatchInput(fp *fryatogParams, cardGetFunction CardGetter, dum
 		// Last time it bit us, the query '!ruling kozilek the great distortion 1'
 		// was getting chopped off because we had this capped at 35.
 		// Maybe look for some way to make this more robust and Actually Programmatic.
-		if !strings.HasPrefix(message, "search ") && !strings.HasPrefix(message, "wow") && len(message) > 41 {
+		if !strings.HasPrefix(message, "search ") && !strings.HasPrefix(message, "random ") && !strings.HasPrefix(message, "wow") && len(message) > 41 {
 			message = message[0:41]
 		}
 


### PR DESCRIPTION
Noticed by users on IRC. Random card requests such as `!random o:"deals 5 damage to target creature"` were failing to process, because the message exceeded 41 characters and was getting cut off. Just like `!search`, `!random` should get an exception from this rule, so now it does.