### PR TITLE
Update CR endpoint

### DIFF
--- a/rules.go
+++ b/rules.go
@@ -78,7 +78,7 @@ func findRule(input string, which string) (Rule, error) {
 		return Rule{}, errors.New("Unknown mode")
 	}
 
-	url := endpoint + input
+	url := endpoint + input + "?find_definition=true"
 	log.Debug("findRule: Attempting to fetch", "URL", url)
 	resp, err := http.Get(url)
 	if err != nil {


### PR DESCRIPTION
The CR endpoint [recently changed](https://github.com/lunakv/academyruins-api/releases/tag/v0.7.0) from being fuzzy by default (automatically redirecting to definitions of keywords) to being exact by default. This commits adds the new flag that enables the endpoint to be fuzzy to the rules endpoint to keep the behavior of the bot consistent.
