### PR TITLE
Make configuration more flexible

### DIFF
--- a/config-EXAMPLE.json
+++ b/config-EXAMPLE.json
@@ -1,6 +1,6 @@
 {
-    "DSN": "https://sentry.io",
-    "Password": "",
+    "DSN": "https://sentry.io (can also be set using the SENTRY_DSN env variable)",
+    "Password": "(can also be set using the IRC_PASSWORD env variable)",
     "DevMode": true,
     "Server": {
         "SSL": "irc.libera.chat:6697",
@@ -18,7 +18,7 @@
     "ProdNick": "Fryatog",
     "DevNick": "Fryatog-Dev",
     "SlackTokens": [
-        ""
+        "(can also be set as a comma-separated list in the SLACK_TOKENS env variable)"
      ],
      "Hearthstone": {
         "AppID": "",

--- a/configuration.go
+++ b/configuration.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+
+	log "gopkg.in/inconshreveable/log15.v2"
+)
+
+// Configuration lists the configurable parameters, stored in config.json
+type configuration struct {
+	DSN      string `json:"DSN"`
+	Password string `json:"Password"`
+	DevMode  bool   `json:"DevMode"`
+	Server   struct {
+		SSL    string `json:"SSL"`
+		NonSSL string `json:"NonSSL"`
+	}
+	ProdChannels []string `json:"ProdChannels"`
+	DevChannels  []string `json:"DevChannels"`
+	Ops          []string `json:"Ops"`
+	ProdNick     string   `json:"ProdNick"`
+	DevNick      string   `json:"DevNick"`
+	SlackTokens  []string `json:"SlackTokens"`
+	Hearthstone  struct {
+		AppID     string `json:"AppID"`
+		APIToken  string `json:"APIToken"`
+		IndexName string `json:"IndexName"`
+	} `json:"Hearthstone"`
+	BattleNet struct {
+		ClientID         string   `json:"ClientID"`
+		ClientSecret     string   `json:"ClientSecret"`
+		CurrentExpansion string   `json:"CurrentExpansion"`
+		CurrentRaidTier  string   `json:"CurrentRaidTier"`
+		Reputations      []string `json:"Reputations"`
+	} `json:"BattleNet"`
+	PoE struct {
+		League           string   `json:"League"`
+		WantedCurrencies []string `json:"WantedCurrencies"`
+	} `json:"PoE"`
+	IRC   bool `json:"IRC"`
+	Slack bool `json:"Slack"`
+}
+
+const (
+	defaultConfigFilePath  = "config.json"
+	configPathEnvVariable  = "CONFIG_PATH"
+	passwordEnvVariable    = "IRC_PASSWORD"
+	dsnEnvVariable         = "SENTRY_DSN"
+	slackTokensEnvVariable = "SLACK_TOKENS"
+)
+
+func readConfig() configuration {
+	file, err := os.Open(getConfigFilePath())
+	if err != nil {
+		panic(err)
+	}
+	defer file.Close()
+	decoder := json.NewDecoder(file)
+	conf := configuration{}
+	err = decoder.Decode(&conf)
+	if err != nil {
+		panic(err)
+	}
+	log.Debug("Conf", "Parsed as", conf)
+	return conf
+}
+
+func getConfigFilePath() string {
+	path := os.Getenv(configPathEnvVariable)
+	if path == "" {
+		path = defaultConfigFilePath
+	}
+	return path
+}
+
+func getPassword(conf *configuration) string {
+	password := os.Getenv(passwordEnvVariable)
+	if password == "" {
+		password = conf.Password
+	}
+	return password
+}
+
+func getDSN(conf *configuration) string {
+	dsn := os.Getenv(dsnEnvVariable)
+	if dsn == "" {
+		dsn = conf.DSN
+	}
+	return dsn
+}
+
+func getSlackTokens(conf *configuration) []string {
+	tokenStr := os.Getenv(slackTokensEnvVariable)
+	if tokenStr == "" {
+		return conf.SlackTokens
+	}
+	return strings.Split(tokenStr, ",")
+}

--- a/dice.go
+++ b/dice.go
@@ -171,5 +171,3 @@ func formatFlips(flips []int, count int) string {
 
 	return fmt.Sprintf("%s%s.", prefix, strings.Join(formatted, joiner))
 }
-
-

--- a/rules.go
+++ b/rules.go
@@ -4,11 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
-	"strings"
-	"strconv"
 	raven "github.com/getsentry/raven-go"
 	log "gopkg.in/inconshreveable/log15.v2"
+	"net/http"
+	"strconv"
+	"strings"
 )
 
 const rulesEndpointURL = "https://api.academyruins.com/cr/"
@@ -103,7 +103,7 @@ func handleExampleQuery(input string) string {
 	var (
 		foundRuleNum string
 		exampleIndex int
-		err			 error
+		err          error
 	)
 	exampleRequests.Add(1)
 	fss := ruleExampleRegexp.FindStringSubmatch(input)

--- a/utils.go
+++ b/utils.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/gob"
-	"encoding/json"
 	"expvar"
 	"fmt"
 	"os"
@@ -209,22 +208,6 @@ func cappedMin(a, b, c int) int {
 		return b
 	}
 	return max(a, b)
-}
-
-func readConfig() configuration {
-	file, err := os.Open(configFile)
-	if err != nil {
-		panic(err)
-	}
-	defer file.Close()
-	decoder := json.NewDecoder(file)
-	conf := configuration{}
-	err = decoder.Decode(&conf)
-	if err != nil {
-		panic(err)
-	}
-	log.Debug("Conf", "Parsed as", conf)
-	return conf
 }
 
 func dumpCardCacheTimer(conf *configuration, cache *lru.ARCCache) {


### PR DESCRIPTION
- **Add environment variable for config location**: in case the default './config.json' isn't suitable for some deployment, it's nice to have the option to change it
- **Allow secrets to be defined through environment variables**: I don't love that I have to store my DSN and password in the config file, and that it's logged on startup. I'd much rather those values be configurable through the environment

I also moved all the configuration-related logic into its own file, since it is kind of scattered between main.go and utils.go, and added some small formatting fixes, courtesy of `go fmt`.
