### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/runtests.yaml
+++ b/.github/workflows/runtests.yaml
@@ -1,5 +1,7 @@
 name: runtests
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Fryyyyy/Fryatog/security/code-scanning/2](https://github.com/Fryyyyy/Fryatog/security/code-scanning/2)

In general, the fix is to explicitly define a `permissions` block to restrict the `GITHUB_TOKEN` to the minimal required scope. For this workflow, the steps are: set up Go, check out the repository, and run tests. These operations only require read access to repository contents, and no write access or special scopes (like `issues`, `pull-requests`, etc.). Therefore, the least-privilege fix is to add `permissions: contents: read`.

The single best way to fix this without changing existing functionality is to add a top-level `permissions` block, so it applies to all jobs (currently just `build`). This keeps the YAML simple and ensures any future jobs inherit the restricted permissions by default unless they explicitly override them. Concretely, edit `.github/workflows/runtests.yaml` to insert:

```yaml
permissions:
  contents: read
```

between the `on:` and `jobs:` keys. No additional imports, methods, or other definitions are needed; this is purely a configuration change in the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
